### PR TITLE
chore: remove unecessary dependency

### DIFF
--- a/requirements/requirements.txt
+++ b/requirements/requirements.txt
@@ -4,4 +4,4 @@ pydantic>=1.8.2,<2.0.0
 aioredis>=2.0.0,<3.0.0
 typing-extensions>=4.0.0,<5.0.0
 setuptools~=75.1.0
-rate_limiter~=0.1.0
+


### PR DESCRIPTION
Removed the rate limiter dependency.

If needed, can be installed with `pip install -e .` 